### PR TITLE
Creates tasks for each query and runs them concurrently using `tokio:task::spawn` making it have a lighter CPU load.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
+use tokio::task;
 
 #[derive(Serialize)]
 struct SnowflakeQueryRequest<'a> {
@@ -38,24 +39,48 @@ async fn execute_snowflake_query(
     Ok(response)
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn execute_multiple_queries() -> Result<(), Box<dyn Error>> {
     let client = Client::new();
     let url = "https://<account>.snowflakecomputing.com/api/v2/statements";
-    let query = "SELECT CURRENT_TIMESTAMP;";
     let token = "<your_oauth_token>";
 
-    match execute_snowflake_query(&client, url, query, token).await {
-        Ok(response) => {
-            for row in response.data.rowset {
-                println!("{:?}", row);
+    let queries = vec![
+        "SELECT CURRENT_TIMESTAMP;",
+        "SELECT COUNT(*) FROM my_table;",
+        "SELECT * FROM my_table LIMIT 10;",
+    ];
+
+    let mut tasks = vec![];
+
+    for query in queries {
+        let client = client.clone();
+        let url = url.to_string();
+        let token = token.to_string();
+
+        tasks.push(task::spawn(async move {
+            match execute_snowflake_query(&client, &url, query, &token).await {
+                Ok(response) => {
+                    println!("Query: {}", query);
+                    for row in response.data.rowset {
+                        println!("{:?}", row);
+                    }
+                    println!("Total rows: {}", response.data.total);
+                }
+                Err(err) => {
+                    eprintln!("Error executing query '{}': {}", query, err);
+                }
             }
-            println!("Total rows: {}", response.data.total);
-        }
-        Err(err) => {
-            eprintln!("Error executing query: {}", err);
-        }
+        }));
+    }
+
+    for task in tasks {
+        task.await??;
     }
 
     Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    execute_multiple_queries().await
 }


### PR DESCRIPTION
This approach with [tokio](https://github.com/tokio-rs/tokio) will execute multiple Snowflake queries concurrently and print the results. This approach utilizes Tokio's asynchronous capabilities to handle multiple tasks efficiently and have much lower CPU load and usage.

Cheers,
Michael Mendy